### PR TITLE
Upgraded glide version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,5 +29,5 @@ repositories {
 
 dependencies {
     implementation project(':sandriosCamera')
-    implementation "com.android.support:appcompat-v7:27.0.1"
+    implementation "com.android.support:appcompat-v7:27.0.2"
 }

--- a/sandriosCamera/build.gradle
+++ b/sandriosCamera/build.gradle
@@ -124,14 +124,15 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.android.support:support-v4:27.0.1'
-    implementation 'com.android.support:appcompat-v7:27.0.1'
-    implementation 'com.android.support:recyclerview-v7:27.0.1'
-    implementation 'com.android.support:design:27.0.1'
-    implementation "io.reactivex.rxjava2:rxandroid:2.0.1"
-    implementation "io.reactivex.rxjava2:rxjava:2.1.5"
-    implementation 'com.github.bumptech.glide:glide:3.8.0'
-    implementation 'com.yalantis:ucrop:2.2.0'
-    implementation 'com.karumi:dexter:4.2.0'
+    api 'com.android.support:support-v4:27.0.2'
+    api 'com.android.support:appcompat-v7:27.0.2'
+    api 'com.android.support:recyclerview-v7:27.0.2'
+    api 'com.android.support:design:27.0.2'
+    api "io.reactivex.rxjava2:rxandroid:2.0.1"
+    api "io.reactivex.rxjava2:rxjava:2.1.5"
+    api 'com.github.bumptech.glide:glide:4.4.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.4.0'
+    api 'com.yalantis:ucrop:2.2.0'
+    api 'com.karumi:dexter:4.2.0'
 }
 

--- a/sandriosCamera/src/main/java/com/sandrios/sandriosCamera/internal/ui/view/ImageGalleryAdapter.java
+++ b/sandriosCamera/src/main/java/com/sandrios/sandriosCamera/internal/ui/view/ImageGalleryAdapter.java
@@ -13,6 +13,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.request.RequestOptions;
 import com.sandrios.sandriosCamera.R;
 import com.sandrios.sandriosCamera.internal.SandriosCamera;
 import com.sandrios.sandriosCamera.internal.configuration.CameraConfiguration;
@@ -141,10 +142,10 @@ public class ImageGalleryAdapter extends RecyclerView.Adapter<ImageGalleryAdapte
             Glide.with(context)
                     .load(uri)
                     .thumbnail(0.1f)
-                    .dontAnimate()
-                    .centerCrop()
-                    .placeholder(ContextCompat.getDrawable(context, R.drawable.ic_gallery))
-                    .error(ContextCompat.getDrawable(context, R.drawable.ic_error))
+                    .apply(RequestOptions.centerCropTransform()
+                        .dontAnimate()
+                        .placeholder(ContextCompat.getDrawable(context, R.drawable.ic_gallery))
+                        .error(ContextCompat.getDrawable(context, R.drawable.ic_error)))
                     .into(holder.iv_thumbnail);
 
             if (onItemClickListener != null) {


### PR DESCRIPTION
Upgraded the glide version to the latest version (4.4.0) to prevent conflicts with consumers that use  newer version of glide. 

Changed implementation lines in gradle to api to allow the dependencies of the library to be transitively applied to the project consuming the library.

Changed the support library version to 27.0.2 just to match that found in Glide.